### PR TITLE
#35198: Log metrics for apps launched outside of registered command framework

### DIFF
--- a/python/tk_houdini_alembicnode/handler.py
+++ b/python/tk_houdini_alembicnode/handler.py
@@ -449,11 +449,7 @@ class TkAlembicNodeHandler(object):
         self.set_profile(node)
 
         try:
-            self._app.log_metric("Create")
-            self._app.engine.log_user_attribute_metric(
-                "%s version" % (self._app.name,),
-                self._app.version,
-            )
+            self._app.log_metric("Create", log_version=True)
         except:
             # ingore any errors. ex: metrics logging not supported
             pass

--- a/python/tk_houdini_alembicnode/handler.py
+++ b/python/tk_houdini_alembicnode/handler.py
@@ -448,6 +448,16 @@ class TkAlembicNodeHandler(object):
         # apply the default profile
         self.set_profile(node)
 
+        try:
+            self._app.log_metric("Create")
+            self._app.engine.log_user_attribute_metric(
+                "%s version" % (self._app.name,),
+                self._app.version,
+            )
+        except:
+            # ingore any errors. ex: metrics logging not supported
+            pass
+
 
     ############################################################################
     # Private methods


### PR DESCRIPTION
This change logs the app version and one action metric for "export".
