### PR TITLE
#44077 Adds app-level methods to query nodes and output path

### DIFF
--- a/app.py
+++ b/app.py
@@ -105,4 +105,9 @@ class TkAlembicNodeApp(sgtk.platform.Application):
         self.log_debug("Retrieved output path: %s" % (output_path,))
         return output_path
 
+    def get_work_file_template(self):
+        """
+        Returns the configured work file template for the app.
+        """
 
+        return self.get_template("work_file_template")

--- a/app.py
+++ b/app.py
@@ -67,4 +67,42 @@ class TkAlembicNodeApp(sgtk.platform.Application):
         tk_houdini_alembic.TkAlembicNodeHandler.\
             convert_back_to_tk_alembic_nodes(self)
 
+    def get_nodes(self):
+        """
+        Returns a list of hou.node objects for each tk alembic node.
+
+        Example usage::
+
+        >>> import sgtk
+        >>> eng = sgtk.platform.current_engine()
+        >>> app = eng.apps["tk-houdini-alembicnode"]
+        >>> tk_alembic_nodes = app.get_nodes()
+        """
+
+        self.log_debug("Retrieving tk-houdini-alembic nodes...")
+        tk_houdini_alembic = self.import_module("tk_houdini_alembicnode")
+        nodes = tk_houdini_alembic.TkAlembicNodeHandler.\
+            get_all_tk_alembic_nodes()
+        self.log_debug("Found %s tk-houdini-alembic nodes." % (len(nodes),))
+        return nodes
+
+    def get_output_path(self, node):
+        """
+        Returns the evaluated output path for the supplied node.
+
+        Example usage::
+
+        >>> import sgtk
+        >>> eng = sgtk.platform.current_engine()
+        >>> app = eng.apps["tk-houdini-alembicnode"]
+        >>> output_path = app.get_output_path(tk_alembic_node)
+        """
+
+        self.log_debug("Retrieving output path for %s" % (node,))
+        tk_houdini_alembic = self.import_module("tk_houdini_alembicnode")
+        output_path = tk_houdini_alembic.TkAlembicNodeHandler.\
+            get_output_path(node)
+        self.log_debug("Retrieved output path: %s" % (output_path,))
+        return output_path
+
 

--- a/python/tk_houdini_alembicnode/handler.py
+++ b/python/tk_houdini_alembicnode/handler.py
@@ -164,7 +164,6 @@ class TkAlembicNodeHandler(object):
             app.log_debug("Converted: Alembic node '%s' to TK Alembic node."
                 % (alembic_node_name,))
 
-
     @classmethod
     def convert_to_regular_alembic_nodes(cls, app):
         """Convert Toolkit Alembic nodes to regular Alembic nodes.
@@ -253,6 +252,35 @@ class TkAlembicNodeHandler(object):
             app.log_debug("Converted: Tk Alembic node '%s' to Alembic node."
                 % (tk_alembic_node_name,))
 
+    @classmethod
+    def get_all_tk_alembic_nodes(cls):
+        """
+        Returns a list of all tk-houdini-alembic node instances in the current
+        session.
+        """
+
+        tk_node_type = TkAlembicNodeHandler.TK_ALEMBIC_NODE_TYPE
+
+        # get all instances of tk alembic rop/sop nodes
+        tk_alembic_nodes = []
+        tk_alembic_nodes.extend(
+            hou.nodeType(hou.sopNodeTypeCategory(),
+                         tk_node_type).instances())
+        tk_alembic_nodes.extend(
+            hou.nodeType(hou.ropNodeTypeCategory(),
+                         tk_node_type).instances())
+
+        return tk_alembic_nodes
+
+    @classmethod
+    def get_output_path(cls, node):
+        """
+        Returns the evaluated output path for the supplied node.
+        """
+
+        output_parm = node.parm(cls.NODE_OUTPUT_PATH_PARM)
+        path = output_parm.menuLabels()[output_parm.eval()]
+        return path
 
     ############################################################################
     # Instance methods

--- a/python/tk_houdini_alembicnode/handler.py
+++ b/python/tk_houdini_alembicnode/handler.py
@@ -255,7 +255,7 @@ class TkAlembicNodeHandler(object):
     @classmethod
     def get_all_tk_alembic_nodes(cls):
         """
-        Returns a list of all tk-houdini-alembic node instances in the current
+        Returns a list of all tk-houdini-alembicnode instances in the current
         session.
         """
 


### PR DESCRIPTION
Adds `get_nodes()` and `get_output_path(node)` methods to the app. This allows apps like publisher to ask the installed `tk-houdini-alembicnode` app for information that it knows how to get. This avoids some of the not-so-great code in publish1 where it was relying on internal knowledge of the alembicnode app to collect items for publish. 