### PR TITLE
SG-36195 Add minimum Python version 3.9

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -90,6 +90,7 @@ description: "Support for the Toolkit Alembic output node in Houdini."
 requires_shotgun_version:
 requires_core_version: "v0.12.5"
 requires_engine_version: "v1.7.1"
+minimum_python_version: "3.9"
 
 # the engines that this app can operate in:
 supported_engines: [tk-houdini]


### PR DESCRIPTION
## Summary

Add `minimum_python_version: "3.9"` to `info.yml`.

## Context

Part of [SG-36195](https://jira.autodesk.com/browse/SG-36195) - Remove compatibility with Python 3.7. Breaking date was 2026-04-01 (passed). New minimum version is Python 3.9.

This is a Stage 1 change (leaf app, no framework dependencies).

## Changes

- `info.yml`: added `minimum_python_version: "3.9"`

## Checklist

- [x] `minimum_python_version: "3.9"` added to `info.yml`
- [x] No Python version guards in source code
- [x] No `isAlive` or `cElementTree` usage
- [x] CI pipeline uses shared template (no per-repo Python matrix to update)