### PR TITLE
SG-43662 Drop Python 3.7 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ exclude: "ui\/.*py$"
 # List of super useful formatters.
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     # Ensures the code is syntaxically correct
     - id: check-ast
@@ -33,7 +33,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 26.5.1
     hooks:
     - id: black
       language_version: python3

--- a/info.yml
+++ b/info.yml
@@ -90,6 +90,7 @@ description: "Support for the Toolkit Alembic output node in Houdini."
 requires_shotgun_version:
 requires_core_version: "v0.12.5"
 requires_engine_version: "v1.7.1"
+minimum_python_version: "3.9"
 
 # the engines that this app can operate in:
 supported_engines: [tk-houdini]


### PR DESCRIPTION
## Summary

- Set `minimum_python_version: 3.9` in `info.yml` to declare that this app no longer supports Python 3.7
- Bumped pre-commit hook versions

## Test plan

- [ ] Verify `info.yml` contains `minimum_python_version: 3.9`
- [ ] Pre-commit passes cleanly